### PR TITLE
Incorrectly calculated size in response.

### DIFF
--- a/src/serialbus/qmodbuspdu.cpp
+++ b/src/serialbus/qmodbuspdu.cpp
@@ -752,7 +752,7 @@ int QModbusResponse::calculateDataSize(const QModbusResponse &response)
         }
 
         const QByteArray data = response.data();
-        quint8 numOfObjects = quint8(data[5]);
+        quint8 numOfObjects = (data[4]==0)?  quint8(data[5])-quint8(data[6]) : quint8(data[4])-quint8(data[6]);
         quint8 objectSize = quint8(data[7]);
 
         // 6 byte header size + (2 * n bytes fixed per object) + first object size


### PR DESCRIPTION
Incorrectly calculated the number of objects in the response if it does not correspond to the total number of objects.